### PR TITLE
Added port and puttyForceScp to .scpconfig.json

### DIFF
--- a/.scpconfig.json
+++ b/.scpconfig.json
@@ -1,12 +1,14 @@
 {
-    "host": "10.90.0.45",
-    "username": "root",
-    "remoteDirectory": "/web/test/",
-    "usePuttyTools": false,
-    "puttyPath": "",
-    "privateKey": "/home/nd/.ssh/nd.key",
-    "ignore": [
-      "node_modules",
-      ".git"
-    ]
-  }
+  "host": "10.90.0.45",
+  "username": "root",
+  "port": 22,
+  "remoteDirectory": "/web/test/",
+  "usePuttyTools": false,
+  "puttyPath": "",
+  "puttyForceScp": true,
+  "privateKey": "/home/nd/.ssh/nd.key",
+  "ignore": [
+    "node_modules",
+    ".git"
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## [Version 0.0.6]
+
+- (RewsterUK) Added -P {port} to pscp and plink argument, for hosts not using the default of 22.  
+- (RewsterUK) Added -scp to pscp (putty) for windows if puttyForceScp set, tries and fails to connect to sftp on device without sftp installed.  
+
 ## [Version 0.0.5]
 
 - Fixed Bug: Asysnc error

--- a/README.md
+++ b/README.md
@@ -37,9 +37,11 @@ Create a file named `.scpconfig.json` and add the following content:
 {
   "username": "your-username",
   "host": "your-host",
+  "port": 22,
   "remoteDirectory": "/path/to/remote/directory",
   "usePuttyTools": true, // Only for Windows users
   "puttyPath": "C:\\path\\to\\putty\\directory", // Only for Windows users
+  "puttyForceScp": true, // Only for Windows users
   "privateKey": "C:\\path\\to\\private\\key" // Path to your private key file (either OpenSSH or PuTTY format)
 }
 ``` 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "wl-scp-o-nator",
   "displayName": "SCP-O-Nator",
   "description": "A simple file transfer for projects to and from servers suporting scp (ssh file transfer).",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "engines": {
     "vscode": "^1.7.0"
   },

--- a/src/scponator.js
+++ b/src/scponator.js
@@ -225,6 +225,8 @@ function createRemoteDirectory(config, remoteDir, callback, retryCount = 3, dela
 }
 function buildScpCommand(config, source, userHost, destination, action) {
     let authOptions = '';
+    let portOptions = '';
+    let scpOptions = '';
 
     // Determine if using PuTTY tools (Windows) or OpenSSH tools (Linux/macOS)
     if (config.usePuttyTools) {
@@ -232,22 +234,35 @@ function buildScpCommand(config, source, userHost, destination, action) {
         if (config.privateKey) {
             authOptions = `-i "${config.privateKey}"`;
         }
+        // Add port if given (pscp port -P)
+        if (config.port) {
+            portOptions = `-P ${config.port}`;
+        }
+        // Add -scp if forced      
+        if (config.puttyForceScp === true) {
+            scpOptions =`-scp`;
+        }
+
         // PSCP command format for upload/download
         if (action === 'upload') {
-            return `"${config.puttyPath}\\pscp.exe" ${authOptions} "${source}" ${userHost}:${destination}`;
+            return `"${config.puttyPath}\\pscp.exe" ${scpOptions} ${portOptions} ${authOptions} "${source}" ${userHost}:${destination}`;
         } else if (action === 'download') {
-            return `"${config.puttyPath}\\pscp.exe" ${authOptions} ${userHost}:${source} "${destination}"`;
+            return `"${config.puttyPath}\\pscp.exe" ${scpOptions} ${portOptions} ${authOptions} ${userHost}:${source} "${destination}"`;
         }
     } else {
         // For OpenSSH tools, use the standard private key usage
         if (config.privateKey) {
             authOptions = `-i ${config.privateKey}`;
         }
+        // Add port if given (scp port -P)
+        if (config.port) {
+            portOptions = `-P ${config.port}`;
+        }
         // SCP command format for upload/download
         if (action === 'upload') {
-            return `scp ${authOptions} -r "${source}" ${userHost}:${destination}`;
+            return `scp ${portOptions} ${authOptions} -r "${source}" ${userHost}:${destination}`;
         } else if (action === 'download') {
-            return `scp ${authOptions} -r ${userHost}:${source} "${destination}"`;
+            return `scp ${portOptions} ${authOptions} -r ${userHost}:${source} "${destination}"`;
         }
     }
 }
@@ -255,6 +270,7 @@ function buildScpCommand(config, source, userHost, destination, action) {
 
 function buildMkdirCommand(config, remoteDir) {
     let authOptions = '';
+    let portOptions = '';
 
     // Determine if using PuTTY tools (Windows) or OpenSSH tools (Linux/macOS)
     if (config.usePuttyTools) {
@@ -262,15 +278,23 @@ function buildMkdirCommand(config, remoteDir) {
         if (config.privateKey) {
             authOptions = `-i "${config.privateKey}"`;
         }
+        // Add port if given (plink port -P)
+        if (config.port) {
+            portOptions = `-P ${config.port}`;
+        }
         // Plink command for directory creation
-        return `"${config.puttyPath}\\plink.exe" ${authOptions} ${config.username}@${config.host} "mkdir -p ${remoteDir}"`;
+        return `"${config.puttyPath}\\plink.exe" ${portOptions} ${authOptions} ${config.username}@${config.host} "mkdir -p ${remoteDir}"`;
     } else {
         // For OpenSSH tools, standard private key usage
         if (config.privateKey) {
             authOptions = `-i ${config.privateKey}`;
         }
+        // Add port if given (ssh port -p)
+        if (config.port) {
+            portOptions = `-p ${config.port}`;
+        }
         // SSH command for directory creation
-        return `ssh  ${authOptions} ${config.username}@${config.host} "mkdir -p ${remoteDir}"`;
+        return `ssh ${portOptions} ${authOptions} ${config.username}@${config.host} "mkdir -p ${remoteDir}"`;
     }
 }
 


### PR DESCRIPTION
Added the following options to .scpoptions.json

Port
Adds -P {Port} to the windows pscp.exe arguments

puttyForceSCP
Adds -scp to windows pscp.exe arguments as the default seems to be -sftp if not specified