### PR TITLE
Fixed compare & added preserveAttributes feature

### DIFF
--- a/.scpconfig.json
+++ b/.scpconfig.json
@@ -7,6 +7,7 @@
     "puttyPath": "",
     "privateKey": "/home/nd/.ssh/nd.key",
     "forceScpProtocol": false,
+    "PreserveAttributes": false,
     "ignore": [
       "node_modules",
       ".git"

--- a/src/scponator.js
+++ b/src/scponator.js
@@ -373,11 +373,14 @@ async function compareLocalVsRemote(uri) {
         const localStats = fs.statSync(localPath);
         const localSize = localStats.size;
         const localMtime = localStats.mtime;
+        // Add port for plink or ssh if specified
+        const portOptionPlink = config.port && config.port !== 22 ? `-P ${config.port}` : '';
+        const portOptionSsh   = config.port && config.port !== 22 ? `-p ${config.port}` : '';
         
         // Get remote file stats using SSH
         const statCommand = config.usePuttyTools 
-            ? `"${config.puttyPath}\\plink.exe" -i "${config.privateKey}" ${config.username}@${config.host} "stat -c '%s %Y' ${remotePath}"`
-            : `ssh -i "${config.privateKey}" ${config.username}@${config.host} "stat -c '%s %Y' ${remotePath}"`;
+            ? `"${config.puttyPath}\\plink.exe" ${portOptionPlink} -i "${config.privateKey}" ${config.username}@${config.host} "stat -c '%s %Y' ${remotePath}"`
+            : `ssh ${portOptionSsh} -i "${config.privateKey}" ${config.username}@${config.host} "stat -c '%s %Y' ${remotePath}"`;
         
         executeCommandWithEnv(statCommand, (err, stdout, stderr) => {
             updateStatusBar();


### PR DESCRIPTION
The compare files function was missing {portOptions} for Plink and Ssh

Added a preserveAttributes on upload and download, keeping the date the same as the original