### PR TITLE
Added Show File Diff (Remote Vs Local) Feature

### DIFF
--- a/.scpconfig.json
+++ b/.scpconfig.json
@@ -7,7 +7,7 @@
     "puttyPath": "",
     "privateKey": "/home/nd/.ssh/nd.key",
     "forceScpProtocol": false,
-    "PreserveAttributes": false,
+    "preserveAttributes": false,
     "ignore": [
       "node_modules",
       ".git"

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Create a file named `.scpconfig.json` and add the following content:
   "puttyPath": "C:\\path\\to\\putty\\directory", // Only for Windows users
   "privateKey": "C:\\path\\to\\private\\key", // Path to your private key file (either OpenSSH or PuTTY format)
   "forceScpProtocol": false, // Set to true for compatibility with older devices like OpenWrt
+  "preserveAttributes": false, // Set to true to maintain original file dates during transfers
   "ignore": [
     "node_modules",
     ".git",
@@ -154,6 +155,7 @@ To download the corresponding remote file to your local directory, press `Ctrl+D
 - `usePuttyTools`: Set to `true` for Windows users with PuTTY tools
 - `puttyPath`: Path to PuTTY tools directory (Windows only)
 - `forceScpProtocol`: Set to `true` to force SCP protocol for older devices
+- `preserveAttributes`: Set to `true` to maintain original file dates during transfers
 - `ignore`: Array of patterns to ignore during project transfers
 
 ## Troubleshooting

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "onCommand:scponator.testConnection",
     "onCommand:scponator.retryFailed",
     "onCommand:scponator.compareFiles",
-    "onCommand:scponator.syncDirectory"
+    "onCommand:scponator.syncDirectory",
+    "onCommand:scponator.showFileDiff"
   ],
   "repository": {
     "type": "git",
@@ -73,6 +74,10 @@
       {
         "command": "scponator.compareFiles",
         "title": "Compare Local vs Remote"
+      },
+      {
+        "command": "scponator.showFileDiff",
+        "title": "Show Diff Remote vs Local"
       },
       {
         "command": "scponator.syncDirectory",
@@ -133,6 +138,11 @@
         {
           "command": "scponator.compareFiles",
           "group": "wlscponator@2"
+        },
+        {
+          "command": "scponator.showFileDiff",
+          "group": "wlscponator@2",
+          "when": "resourceScheme == file && explorerResourceIsFolder == false && listMultiSelection == false"
         },
         {
           "command": "scponator.syncDirectory",


### PR DESCRIPTION
Added a Show File Diff (Remote Vs Local) Feature, this works by downloading the remote file to a temp folder/file (virtual read-only file in memory), then comparing this with the local file.

The left pane is Remote (Read Only and Not Editable), and the right is the Local, you can edit this local file.

This menu item only shows if a single file is selected.